### PR TITLE
Avoid property name conversions between camel-case and dashed formats

### DIFF
--- a/js/filters/ShorthandPropertyFilter.js
+++ b/js/filters/ShorthandPropertyFilter.js
@@ -1,37 +1,44 @@
 function ShorthandPropertyFilter() {
 	"use strict";
 
+	function keySet(array) {
+		var i, obj = {};
+		for (i=0; i<array.length; i++)
+			obj[array[i]] = true;
+		return obj;
+	}
+
 	function keepOnlyShorthandProperties(style) {
 		var property,
 			output={},
-			blacklist = [
-				"backgroundPosition","backgroundColor","backgroundImage","backgroundPositionX","backgroundPositionY","backgroundRepeat",
-				"backgroundClip","backgroundOrigin","backgroundRepeatX","backgroundRepeatY",
-				"marginLeft","marginRight","marginTop","marginBottom",
-				"paddingLeft","paddingRight","paddingTop","paddingBottom",
-				"borderLeft","borderRight","borderTop","borderBottom",
-				"borderImageOutset","borderImageRepeat","borderImageSlice","borderImageSource","borderImageWidth",
-				"borderBottomLeftRadius","borderBottomRightRadius","borderTopLeftRadius","borderTopRightRadius",
-				"borderLeftColor","borderRightColor","borderTopColor","borderBottomColor",
-				"borderLeftStyle","borderRightStyle","borderTopStyle","borderBottomStyle",
-				"borderLeftWidth","borderRightWidth","borderTopWidth","borderBottomWidth",
-				"borderColor","borderWidth","borderStyle",
-				"outlineColor","outlineOffset","outlineStyle","outlineWidth",
-				"overflowX","overflowY",
-				"fontFamily", "fontSize", "fontStreach", "fontVariant", "fontWeight",
-				"listStyleType","listStyleImage","listStylePosition",
-				"transitionDelay","transitionProperty","transitionDuration","transitionTimingFunction",
-				"webkitBorderAfter","webkitBorderAfterColor","webkitBorderBefore","webkitBorderBeforeColor","webkitBorderEnd","webkitBorderEndColor","webkitBorderStart","webkitBorderStartColor",
-				"webkitBorderAfterWidth","webkitBorderAfterStyle","webkitBorderBeforeWidth","webkitBorderBeforeStyle","webkitBorderEndWidth","webkitBorderEndStyle","webkitBorderStartWidth","webkitBorderStartStyle",
-				"webkitLogicalHeight","webkitLogicalWidth",
-				"webkitMinLogicalHeight","webkitMinLogicalWidth","webkitMaxLogicalHeight","webkitMaxLogicalWidth",
-				"webkitColumnRuleColor",
-				"webkitPaddingBefore","webkitPaddingAfter","webkitPaddingStart","webkitPaddingEnd",
-				"webkitMarginBefore","webkitMarginAfter","webkitMarginStart","webkitMarginEnd"
-			];
+			blacklist = keySet([
+				"background-position","background-color","background-image","background-position-x","background-position-y","background-repeat",
+				"background-clip","background-origin","background-repeat-x","background-repeat-y",
+				"margin-left","margin-right","margin-top","margin-bottom",
+				"padding-left","padding-right","padding-top","padding-bottom",
+				"border-left","border-right","border-top","border-bottom",
+				"border-image-outset","border-image-repeat","border-image-slice","border-image-source","border-image-width",
+				"border-bottom-left-radius","border-bottom-right-radius","border-top-left-radius","border-top-right-radius",
+				"border-left-color","border-right-color","border-top-color","border-bottom-color",
+				"border-left-style","border-right-style","border-top-style","border-bottom-style",
+				"border-left-width","border-right-width","border-top-width","border-bottom-width",
+				"border-color","border-width","border-style",
+				"outline-color","outline-offset","outline-style","outline-width",
+				"overflow-x","overflow-y",
+				"font-family", "font-size", "font-stretch", "font-variant", "font-weight",
+				"list-style-type","list-style-image","list-style-position",
+				"transition-delay","transition-property","transition-duration","transition-timing-function",
+				"-webkit-border-after","-webkit-border-after-color","-webkit-border-before","-webkit-border-before-color","-webkit-border-end","-webkit-border-end-color","-webkit-border-start","-webkit-border-start-color",
+				"-webkit-border-after-width","-webkit-border-after-style","-webkit-border-before-width","-webkit-border-before-style","-webkit-border-end-width","-webkit-border-end-style","-webkit-border-start-width","-webkit-border-start-style",
+				"-webkit-logical-height","-webkit-logical-width",
+				"-webkit-min-logical-height","-webkit-min-logical-width","-webkit-max-logical-height","-webkit-max-logical-width",
+				"-webkit-column-rule-color",
+				"-webkit-padding-before","-webkit-padding-after","-webkit-padding-start","-webkit-padding-end",
+				"-webkit-margin-before","-webkit-margin-after","-webkit-margin-start","-webkit-margin-end"
+			]);
 
 		for(property in style) {
-			if( style.hasOwnProperty(property) && blacklist.indexOf(property) === -1 ) {
+			if( style.hasOwnProperty(property) && !blacklist.hasOwnProperty(property) ) {
 				output[property] = style[property];
 			}
 		}

--- a/js/filters/WebkitPropertiesFilter.js
+++ b/js/filters/WebkitPropertiesFilter.js
@@ -6,7 +6,7 @@ function WebkitPropertiesFilter() {
 			output = {};
 
 		for(property in style) {
-			if( style.hasOwnProperty(property) && property.indexOf("webkit") === -1 ) {
+			if( style.hasOwnProperty(property) && !/^-webkit-/.test(property) ) {
 				output[property] = style[property];
 			}
 		}

--- a/js/tools/BorderRadiusWorkaround.js
+++ b/js/tools/BorderRadiusWorkaround.js
@@ -10,27 +10,27 @@ function BorderRadiusWorkaround() {
 		return 0;
 	}
 
-	//fixes a bug in getComputedStyle ( https://code.google.com/p/chromium/issues/detail?id=298972 )
+	// Works around a bug in getComputedStyle ( http://crbug.com/298972, fixed in Chrome 32 )
 	function fixBorderRadius(properties) {
 		var borderFirstRadius = [], borderSecondRadius = [];
 
-		borderFirstRadius[0] = getRadius(properties['borderTopLeftRadius'], 0);
-		borderFirstRadius[1] = getRadius(properties['borderTopRightRadius'], 0);
-		borderFirstRadius[2] = getRadius(properties['borderBottomRightRadius'], 0);
-		borderFirstRadius[3] = getRadius(properties['borderBottomLeftRadius'], 0);
+		borderFirstRadius[0] = getRadius(properties['border-top-left-radius'], 0);
+		borderFirstRadius[1] = getRadius(properties['border-top-right-radius'], 0);
+		borderFirstRadius[2] = getRadius(properties['border-bottom-right-radius'], 0);
+		borderFirstRadius[3] = getRadius(properties['border-bottom-left-radius'], 0);
 
-		borderSecondRadius[0] = getRadius(properties['borderTopLeftRadius'], 1);
-		borderSecondRadius[1] = getRadius(properties['borderTopRightRadius'], 1);
-		borderSecondRadius[2] = getRadius(properties['borderBottomRightRadius'], 1);
-		borderSecondRadius[3] = getRadius(properties['borderBottomLeftRadius'], 1);
+		borderSecondRadius[0] = getRadius(properties['border-top-left-radius'], 1);
+		borderSecondRadius[1] = getRadius(properties['border-top-right-radius'], 1);
+		borderSecondRadius[2] = getRadius(properties['border-bottom-right-radius'], 1);
+		borderSecondRadius[3] = getRadius(properties['border-bottom-left-radius'], 1);
 
-		properties['borderRadius'] = borderFirstRadius.join(' ');
+		properties['border-radius'] = borderFirstRadius.join(' ');
 
 		//if borderSecondRadius != [0,0,0,0] then we need to add information about second radius
 		if(!borderSecondRadius.every(function(a){
 			return (a === 0);
 		})) {
-			properties['borderRadius'] += ' / ' + borderSecondRadius.join(' ');
+			properties['border-radius'] += ' / ' + borderSecondRadius.join(' ');
 		}
 	}
 
@@ -40,13 +40,13 @@ function BorderRadiusWorkaround() {
 		for (i = 0; i < styles.length; i++) {
 			var style = styles[i];
 
-			if(style.node.hasOwnProperty('borderRadius')) {
+			if(style.node.hasOwnProperty('border-radius')) {
 				fixBorderRadius(style.node);
 			}
-			if(style.before && style.before.hasOwnProperty('borderRadius')) {
+			if(style.before && style.before.hasOwnProperty('border-radius')) {
 				fixBorderRadius(style.before);
 			}
-			if(style.after && style.after.hasOwnProperty('borderRadius')) {
+			if(style.after && style.after.hasOwnProperty('border-radius')) {
 				fixBorderRadius(style.after);
 			}
 		}

--- a/js/tools/CSSStringifier.js
+++ b/js/tools/CSSStringifier.js
@@ -1,32 +1,13 @@
 function CSSStringifier() {
 	"use strict";
 
-	function camelCaseToDashes(property) {
-		var i, l,
-			output = "";
-
-		if (property.substr(0, 6) === 'webkit') {
-			output += "-";
-		}
-
-		for (i = 0, l = property.length; i < l; i++) {
-			if (property[i] >= 'A' && property[i] <= 'Z') {
-				output += '-';
-			}
-
-			output += property[i].toLowerCase();
-		}
-
-		return output;
-	}
-
 	function propertiesToString(properties) {
 		var property,
 			output = "";
 
 		for (property in properties) {
 			if (properties.hasOwnProperty(property)) {
-				output += "    " + camelCaseToDashes(property) + ": " + properties[property] + ";\n";
+				output += "    " + property + ": " + properties[property] + ";\n";
 			}
 		}
 
@@ -75,7 +56,7 @@ function CSSStringifier() {
 			if (style.before) {
 				output += printIDs(style.id, ':before') + ' {\n';
 				output += propertiesToString(style.before);
-				output += '}/*' + printIDs(style.id, ':after') + '*/\n\n';
+				output += '}/*' + printIDs(style.id, ':before') + '*/\n\n';
 			}
 		}
 

--- a/js/tools/Snapshooter.js
+++ b/js/tools/Snapshooter.js
@@ -15,17 +15,15 @@ function Snapshooter(root) {
 	 * @returns {}
 	 */
 	function styleDeclarationToSimpleObject(style) {
-		var property,
+		var i, l,
 			output = {};
 
-		for(property in style) {
-
-			if( !style.hasOwnProperty(property) || !isNaN(parseInt(property)) || property === 'cssText' || property === 'length' ) {
-				continue;
-			}
-
-			output[property] = style[property];
+		for(i=0, l=style.length; i<l; i++) {
+			output[style[i]] = style[style[i]];
 		}
+
+		// Work around http://crbug.com/313670 (the "content" property is not present as a computed style indexed property value).
+		output.content = style.content;
 
 		return output;
 	}


### PR DESCRIPTION
The existing approach to property retrieval is redundant and error-prone. The `CSSStyleDeclaration` has the `length` property and indexed properties (CSS property names), akin to `Array` elements.

Drive-by: optimize shorthand property filtering and fix trailing comment for `:before` pseudo-elements.
