### PR TITLE
Use ancestor elements in the generated HTML and CSS

### DIFF
--- a/js/panel.js
+++ b/js/panel.js
@@ -22,6 +22,7 @@
 		removeWebkitPropertiesInput = $('#remove-webkit-properties'),
 		combineSameRulesInput = $('#combine-same-rules'),
 		fixHTMLIndentationInput = $('#fix-html-indentation'),
+		includeAncestors = $('#include-ancestors'),
 
 		htmlTextarea = $('#html'),
 		cssTextarea = $('#css'),
@@ -97,6 +98,11 @@
 
 		var styles = lastSnapshot.css,
 			html = lastSnapshot.html;
+
+		if (includeAncestors.is(':checked')) {
+		  styles = lastSnapshot.ancestorCss.concat(styles);
+		  html = lastSnapshot.leadingAncestorHtml + html + lastSnapshot.trailingAncestorHtml;
+		}
 
 		loader.addClass('processing');
 

--- a/panel.html
+++ b/panel.html
@@ -64,6 +64,9 @@
                                 <input type='checkbox' checked="checked" id='fix-html-indentation'/> Format and clean up
                                 HTML
                             </label></li>
+                            <li><label class="checkbox">
+                                <input type='checkbox' id='include-ancestors'/> Include ancestor elements in the snippet
+                            </label></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
This commit is intended to fix issue #8. Ancestors up to (but not including) BODY are collected into the generated HTML and CSS (if BODY is selected, then all ancestors are collected, but sanitized away from HTML if the option is checked).
